### PR TITLE
fix: formatted tags override by origin tags error

### DIFF
--- a/adapter/hexo.js
+++ b/adapter/hexo.js
@@ -62,8 +62,8 @@ module.exports = function(post) {
   const props = {
     title,
     date,
-    tags: formatTags(tags),
     ...data,
+    tags: formatTags(tags),
   };
   const text = ejs.render(template, {
     raw,


### PR DESCRIPTION
...data
展开操作会把格式化后的tags覆盖掉，格式化tags并没有生效。
本次提交修复该问题。