### PR TITLE
feat: add urlname from slug prop

### DIFF
--- a/adapter/hexo.js
+++ b/adapter/hexo.js
@@ -55,12 +55,13 @@ module.exports = function(post) {
   // matter 解析
   const parseRet = parseMatter(post.body);
   const { body, ...data } = parseRet;
-  const { title, created_at } = post;
+  const { title, slug: urlname, created_at } = post;
   const raw = formatRaw(body);
   const date = data.date || formatDate(created_at);
   const tags = data.tags || [];
   const props = {
     title,
+    urlname,
     date,
     ...data,
     tags: formatTags(tags),


### PR DESCRIPTION
Since we may not want to show chinese title in the url, we can add urlname from slug which comes from yuque api. After modifying `_config.yml` and `scaffolds/post.md` in hexo project, we can use the `urlname` .