### PR TITLE
fix: momentjs warning

### DIFF
--- a/util/index.js
+++ b/util/index.js
@@ -49,7 +49,7 @@ function doubleDigit(num) {
 exports.doubleDigit = doubleDigit;
 
 function formatDate(date) {
-  return moment(date).format('YYYY-MM-DD HH:mm:ss ZZ');
+  return moment(new Date(date).toISOString()).format('YYYY-MM-DD HH:mm:ss ZZ');
 }
 
 exports.formatDate = formatDate;


### PR DESCRIPTION
The warning log:
"Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date()..."