### PR TITLE
feat: 新增过滤 public 文章 && 新增 markdown 格式化 &&去除语雀的锚点

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A downloader for articles from yuque（语雀知识库同步工具）
   - windows: `set YUQUE_TOKEN=xxx && yuque-hexo sync`
 
 ### 配置知识库
+
 > package.json
 
 ```json
@@ -54,22 +55,24 @@ A downloader for articles from yuque（语雀知识库同步工具）
     "baseUrl": "https://www.yuque.com/api/v2",
     "login": "yinzhi",
     "repo": "blog",
-    "onlyPublished": false
+    "onlyPublished": false,
+    "onlyPublic": false
   }
 }
 ```
 
-| 参数名 | 含义 | 默认值 |
-| --- | --- | --- |
-| postPath | 文档同步后生成的路径 | source/_posts/yuque |
-| cachePath | 文档下载缓存文件 | yuque.json |
-| mdNameFormat | 文件名命名方式 (title / slug) | title |
-| adapter | 文档生成格式 (hexo/markdown) | hexo |
-| concurrency | 下载文章并发数 | 5 |
-| baseUrl | 语雀 API 地址 | - |
-| login | 语雀 login (group), 也称为个人路径 | - |
-| repo | 语雀仓库短名称，也称为语雀知识库路径 | - |
-| onlyPublished | 只展示已经发布的文章 | false |
+| 参数名        | 含义                                 | 默认值               |
+| ------------- | ------------------------------------ | -------------------- |
+| postPath      | 文档同步后生成的路径                 | source/\_posts/yuque |
+| cachePath     | 文档下载缓存文件                     | yuque.json           |
+| mdNameFormat  | 文件名命名方式 (title / slug)        | title                |
+| adapter       | 文档生成格式 (hexo/markdown)         | hexo                 |
+| concurrency   | 下载文章并发数                       | 5                    |
+| baseUrl       | 语雀 API 地址                        | -                    |
+| login         | 语雀 login (group), 也称为个人路径   | -                    |
+| repo          | 语雀仓库短名称，也称为语雀知识库路径 | -                    |
+| onlyPublished | 只展示已经发布的文章                 | false                |
+| onlyPublic    | 只展示公开文章                       | false                |
 
 > slug 是语雀的永久链接名，一般是几个随机字母。
 
@@ -117,17 +120,16 @@ DEBUG=yuque-hexo.* yuque-hexo sync
 
 # Notice
 
-* 语雀同步过来的文章会生成两部分文件；
+- 语雀同步过来的文章会生成两部分文件；
 
-  * yuque.json: 从语雀 API 拉取的数据
-  * source/_posts/yuque/*.md: 生成的 md 文件
+  - yuque.json: 从语雀 API 拉取的数据
+  - source/\_posts/yuque/\*.md: 生成的 md 文件
 
-* 支持配置 front-matter, 语雀编辑器编写示例如下:
+- 支持配置 front-matter, 语雀编辑器编写示例如下:
 
-  * 语雀编辑器示例，可参考[原文](https://www.yuque.com/u46795/blog/dlloc7)
+  - 语雀编辑器示例，可参考[原文](https://www.yuque.com/u46795/blog/dlloc7)
 
   ```markdown
-
   tags: [hexo, node]
   categories: fe
   cover: https://cdn.nlark.com/yuque/0/2019/jpeg/155457/1546857679810-d82e3d46-e960-419c-a715-0a82c48a2fd6.jpeg#align=left&display=inline&height=225&name=image.jpeg&originHeight=225&originWidth=225&size=6267&width=225
@@ -141,7 +143,7 @@ DEBUG=yuque-hexo.* yuque-hexo sync
   more detail
   ```
 
-* 如果遇到上传到语雀的图片无法加载的问题，可以参考这个处理方式 [#41](https://github.com/x-cold/yuque-hexo/issues/41)
+- 如果遇到上传到语雀的图片无法加载的问题，可以参考这个处理方式 [#41](https://github.com/x-cold/yuque-hexo/issues/41)
 
 # Example
 

--- a/adapter/hexo.js
+++ b/adapter/hexo.js
@@ -8,14 +8,13 @@ const { formatDate, formatRaw, formatTags, formatList } = require('../util');
 const entities = new Entities();
 
 // 文章模板
-const template = `
----
-<% for (const key in props) {%>
+const template = `---
+<% for (const key in props) {-%>
 <%= key %>: <%= props[key] %>
-<% } %>
+<% } -%>
 ---
-<%- raw %>
-`;
+
+<%- raw -%>`;
 
 /**
  * front matter 反序列化

--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ const defaultConfig = {
   adapter: 'hexo',
   concurrency: 5,
   onlyPublished: false,
+  onlyPublic: false,
 };
 
 function loadConfig() {

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -57,10 +57,9 @@ class Downloader {
     const { client, _cachedArticles } = this;
     return function() {
       out.info(`download article body: ${item.title}`);
-      return client.getArticle(item.slug)
-        .then(({ data: article }) => {
-          _cachedArticles[index] = article;
-        });
+      return client.getArticle(item.slug).then(({ data: article }) => {
+        _cachedArticles[index] = article;
+      });
     };
   }
 
@@ -79,6 +78,7 @@ class Downloader {
     out.info(`article amount: ${articles.data.length}`);
     const realArticles = articles.data
       .filter(article => (config.onlyPublished ? !!article.published_at : true))
+      .filter(article => (config.onlyPublic ? !!article.public : true))
       .map(article => lodash.pick(article, PICK_PROPERTY));
     const queue = new Queue({ concurrency: config.concurrency });
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash": "^4.17.10",
     "mkdirp": "^1.0.0",
     "moment": "^2.22.2",
+    "prettier": "^2.0.4",
     "queue": "^4.5.0",
     "rimraf": "^2.6.2",
     "update-check": "^1.5.3",

--- a/util/index.js
+++ b/util/index.js
@@ -2,6 +2,7 @@
 
 const moment = require('moment');
 const lodash = require('lodash');
+const prettier = require('prettier');
 
 /**
  * 格式化 markdown 中的 tags
@@ -45,10 +46,17 @@ exports.formatList = formatList;
 function formatRaw(body) {
   const multiBr = /(<br>[\s\n]){2}/gi;
   const multiBrEnd = /(<br \/>[\n]?){2}/gi;
-  const brBug = '**<br />';
+  const brBug = /<br \/>/g;
   const hiddenContent = /<div style="display:none">[\s\S]*?<\/div>/gi;
-  return body.replace(hiddenContent, '').replace(multiBr, '<br>').replace(multiBrEnd, '<br />\n')
-    .replace(brBug, '');
+  // 删除语雀特有的锚点
+  const emptyAnchor = /<a name=\".*?\"><\/a>/g;
+  body = body
+    .replace(hiddenContent, '')
+    .replace(multiBr, '<br>')
+    .replace(multiBrEnd, '<br />\n')
+    .replace(brBug, '\n')
+    .replace(emptyAnchor, '');
+  return prettier.format(body, { parser: 'markdown' });
 }
 
 exports.formatRaw = formatRaw;


### PR DESCRIPTION
- 新增过滤 public 文章
   可以选择仅同步公开的文章，可以用于模板文章的排除 https://github.com/x-cold/yuque-hexo/issues/53
   首次使用需要先执行 `yuque-hexo clean`
- 新增去除语雀锚点
   `<a name="b9GY4"></a>`
- 新增 markdown 格式化 
   采用 prettier 进行 markdown 格式化，解决导出文章默认格式比较混乱的问题