### PR TITLE
feat(语雀图片转腾讯云图床): 支持语雀图片转腾讯云图床

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ typings/
 package-lock.json
 
 yarn.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A downloader for articles from yuque（语雀知识库同步工具）
 
 ## Config
 
-### 配置 TOKEN
+### 配置 YUQUE_TOKEN
 
 出于对知识库安全性的调整，使用第三方 API 访问知识库，需要传入环境变量 YUQUE_TOKEN，在语雀上点击 个人头像 -> 设置 -> Token 即可获取。传入 YUQUE_TOKEN 到 yuque-hexo 的进程有两种方式：
 
@@ -37,6 +37,17 @@ A downloader for articles from yuque（语雀知识库同步工具）
 - 命令执行时传入环境变量
   - mac / linux: `YUQUE_TOKEN=xxx yuque-hexo sync`
   - windows: `set YUQUE_TOKEN=xxx && yuque-hexo sync`
+
+### 配置 腾讯云对象存储TOKEN(可选)
+语雀的url存在防盗链的问题，直接部署可能导致图片无法加载。
+如果需要语雀URL上传到腾讯云的COS中并替换原链接，就需要配置上传密钥。
+
+访问[API密钥管理](https://console.cloud.tencent.com/cam/capi) 获取密钥，然后传入密钥到yuque-hexo
+- 在设置YUQUE_TOKEN的基础上配置SECRET_ID和SECRET_KEY
+- 命令执行时传入环境变量
+  - mac / linux: `YUQUE_TOKEN=xxx SECRET_ID=xxx SECRET_KEY=xxx yuque-hexo sync`
+  - windows: `set YUQUE_TOKEN=xxx SECRET_ID=xxx SECRET_KEY=xxx && yuque-hexo sync`
+
 
 ### 配置知识库
 
@@ -56,7 +67,13 @@ A downloader for articles from yuque（语雀知识库同步工具）
     "repo": "blog",
     "onlyPublished": false,
     "onlyPublic": false,
-    "lastGeneratePath": "lastGeneratePath.log"
+    "lastGeneratePath": "lastGeneratePath.log",
+    "imgCdn": {
+      "enabled": false,
+      "bucket": "",
+      "region": "",
+      "prefixKey": ""
+    }
   }
 }
 ```
@@ -74,8 +91,27 @@ A downloader for articles from yuque（语雀知识库同步工具）
 | repo          | 语雀仓库短名称，也称为语雀知识库路径 | -                    |
 | onlyPublished | 只展示已经发布的文章                 | false                |
 | onlyPublic    | 只展示公开文章                       | false                |
-
+| imgCdn        | 语雀图片转CDN配置                    |                |
 > slug 是语雀的永久链接名，一般是几个随机字母。
+
+imgCdn 语雀图片转COS（对象存储）配置说明
+
+注意：开启后会将匹配到的所有的图片都上传到COS
+
+| 参数名        | 含义                                 | 默认值               |
+| ------------- | ------------------------------------ | -------------------- |
+| enabled       | 是否开启                           | false |
+| bucket        | 腾讯COS的bucket名称                     | -          |
+| region        | 腾讯COS的region(地域名称)               |  -                     |
+| prefixKey     | 文件前缀                                | -                |
+> prefixKey 说明
+> 
+> 如果需要将图片上传到COS的根目录，那么prefixKey不用配置。
+> 
+> 如果想上传到指定目录blog/image下，则需要配置prefixKey为"prefixKey": "blog/image"。
+>
+> 目录名前后都不需要加斜杠
+
 
 ## Install
 
@@ -143,8 +179,10 @@ DEBUG=yuque-hexo.* yuque-hexo sync
 
   more detail
   ```
+- 为什么选择腾讯COS作为图床：腾讯的COS费用相对便宜，对于博客来说是非常划算且方便的。
+当然，如果想用其他图床，可以参考源码中实现方式，自行修改配置。
 
-- 如果遇到上传到语雀的图片无法加载的问题，可以参考这个处理方式 [#41](https://github.com/x-cold/yuque-hexo/issues/41)
+- 如果遇到上传到语雀的图片无法加载的问题，可以考虑开启imgCdn配置或者参考这个处理方式 [#41](https://github.com/x-cold/yuque-hexo/issues/41)
 
 # Example
 

--- a/adapter/hexo.js
+++ b/adapter/hexo.js
@@ -4,6 +4,9 @@ const ejs = require('ejs');
 const Entities = require('html-entities').AllHtmlEntities;
 const FrontMatter = require('hexo-front-matter');
 const { formatDate, formatRaw } = require('../util');
+const img2Cos = require('../util/img2cdn');
+const config = require('../config');
+
 
 const entities = new Entities();
 // 背景色区块支持
@@ -60,7 +63,11 @@ function parseMatter(body) {
  * @param {Object} post 文章
  * @return {String} text
  */
-module.exports = function(post) {
+module.exports = async function(post) {
+  // 语雀img转成自己的cdn图片
+  if (config.imgCdn.enabled) {
+    post = await img2Cos(post);
+  }
   // matter 解析
   const parseRet = parseMatter(post.body);
   const { body, ...data } = parseRet;

--- a/adapter/markdown.js
+++ b/adapter/markdown.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { formatRaw } = require('../util');
+const img2Cos = require('../util/img2cdn');
+const config = require('../config');
 
 /**
  * markdown 文章生产适配器
@@ -8,7 +10,11 @@ const { formatRaw } = require('../util');
  * @param {Object} post 文章
  * @return {String} text
  */
-module.exports = function(post) {
+module.exports = async function(post) {
+  // 语雀img转成自己的cdn图片
+  if (config.imgCdn.enabled) {
+    post = await img2Cos(post);
+  }
   const { body } = post;
   const raw = formatRaw(body);
   return raw;

--- a/config.js
+++ b/config.js
@@ -19,6 +19,12 @@ const defaultConfig = {
   concurrency: 5,
   onlyPublished: false,
   onlyPublic: false,
+  imgCdn: {
+    enabled: false,
+    bucket: '',
+    region: '',
+    prefixKey: '',
+  },
 };
 
 function loadConfig() {

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -169,7 +169,7 @@ class Downloader {
    *
    * @param {Object} post 文章详情
    */
-  generatePost(post) {
+  async generatePost(post) {
     if (!isPost(post)) {
       out.error(`invalid post: ${post}`);
       return;
@@ -197,7 +197,7 @@ class Downloader {
       process.exit(-1);
     }
     out.info(`generate post file: ${postPath}`);
-    const text = transform(post);
+    const text = await transform(post);
     fs.writeFileSync(postPath, text, {
       encoding: 'UTF8',
     });
@@ -206,11 +206,11 @@ class Downloader {
   /**
    * 全量生成所有 markdown 文章
    */
-  generatePosts() {
+  async generatePosts() {
     const { _cachedArticles, postBasicPath } = this;
     mkdirp.sync(postBasicPath);
     out.info(`create posts directory (if it not exists): ${postBasicPath}`);
-    _cachedArticles.forEach(this.generatePost);
+    _cachedArticles.forEach(await this.generatePost);
   }
 
   // 文章下载 => 增量更新文章到缓存 json 文件 => 全量生成 markdown 文章
@@ -218,7 +218,7 @@ class Downloader {
     this.readYuqueCache();
     await this.fetchArticles();
     this.writeYuqueCache();
-    this.generatePosts();
+    await this.generatePosts();
     if (this.lastGeneratePath) {
       fs.writeFileSync(this.lastGeneratePath, new Date().getTime().toString());
     }

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -210,7 +210,10 @@ class Downloader {
     const { _cachedArticles, postBasicPath } = this;
     mkdirp.sync(postBasicPath);
     out.info(`create posts directory (if it not exists): ${postBasicPath}`);
-    _cachedArticles.forEach(await this.generatePost);
+    const promiseList = _cachedArticles.map(async item => {
+      return await this.generatePost(item);
+    });
+    await Promise.all(promiseList);
   }
 
   // 文章下载 => 增量更新文章到缓存 json 文件 => 全量生成 markdown 文章

--- a/lib/qetag.js
+++ b/lib/qetag.js
@@ -27,9 +27,11 @@ function getEtag(buffer, callback) {
   let prefix = 0x16;
   let blockCount = 0;
 
+  // eslint-disable-next-line default-case
   switch (mode) {
     case 'buffer':
-      var bufferSize = buffer.length;
+      // eslint-disable-next-line
+      const bufferSize = buffer.length;
       blockCount = Math.ceil(bufferSize / blockSize);
 
       for (let i = 0; i < blockCount; i++) {
@@ -40,9 +42,11 @@ function getEtag(buffer, callback) {
       });
       break;
     case 'stream':
-      var stream = buffer;
+      // eslint-disable-next-line no-case-declarations
+      const stream = buffer;
       stream.on('readable', function() {
         let chunk;
+        // eslint-disable-next-line no-cond-assign
         while (chunk = stream.read(blockSize)) {
           sha1String.push(sha1(chunk));
           blockCount++;

--- a/lib/qetag.js
+++ b/lib/qetag.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// 计算文件的eTag，参数为buffer或者readableStream或者文件路径
+function getEtag(buffer, callback) {
+
+  // 判断传入的参数是buffer还是stream还是filepath
+  let mode = 'buffer';
+
+  if (typeof buffer === 'string') {
+    buffer = require('fs').createReadStream(buffer);
+    mode = 'stream';
+  } else if (buffer instanceof require('stream')) {
+    mode = 'stream';
+  }
+
+  // sha1算法
+  const sha1 = function(content) {
+    const crypto = require('crypto');
+    const sha1 = crypto.createHash('sha1');
+    sha1.update(content);
+    return sha1.digest();
+  };
+
+  // 以4M为单位分割
+  const blockSize = 4 * 1024 * 1024;
+  const sha1String = [];
+  let prefix = 0x16;
+  let blockCount = 0;
+
+  switch (mode) {
+    case 'buffer':
+      var bufferSize = buffer.length;
+      blockCount = Math.ceil(bufferSize / blockSize);
+
+      for (let i = 0; i < blockCount; i++) {
+        sha1String.push(sha1(buffer.slice(i * blockSize, (i + 1) * blockSize)));
+      }
+      process.nextTick(function() {
+        callback(calcEtag());
+      });
+      break;
+    case 'stream':
+      var stream = buffer;
+      stream.on('readable', function() {
+        let chunk;
+        while (chunk = stream.read(blockSize)) {
+          sha1String.push(sha1(chunk));
+          blockCount++;
+        }
+      });
+      stream.on('end', function() {
+        callback(calcEtag());
+      });
+      break;
+  }
+
+  function calcEtag() {
+    if (!sha1String.length) {
+      return 'Fto5o-5ea0sNMlW_75VgGJCv2AcJ';
+    }
+    let sha1Buffer = Buffer.concat(sha1String, blockCount * 20);
+
+    // 如果大于4M，则对各个块的sha1结果再次sha1
+    if (blockCount > 1) {
+      prefix = 0x96;
+      sha1Buffer = sha1(sha1Buffer);
+    }
+
+    sha1Buffer = Buffer.concat(
+      [ new Buffer([ prefix ]), sha1Buffer ],
+      sha1Buffer.length + 1
+    );
+
+    return sha1Buffer.toString('base64')
+      .replace(/\//g, '_').replace(/\+/g, '-');
+
+  }
+
+}
+
+module.exports = getEtag;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yuque-hexo",
+  "name": "yuque-hexo-with-cos",
   "version": "1.8.0",
   "description": "A downloader for articles from yuque",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yuque-hexo-with-cos",
+  "name": "yuque-hexo",
   "version": "1.8.0",
   "description": "A downloader for articles from yuque",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@yuque/sdk": "^1.1.1",
     "chalk": "^2.4.1",
     "common-bin": "^2.7.3",
+    "cos-nodejs-sdk-v5": "^2.11.6",
     "debug": "^3.1.0",
     "depd": "^2.0.0",
     "ejs": "^3.1.6",
@@ -40,6 +41,7 @@
     "prettier": "^2.0.4",
     "queue": "^4.5.0",
     "rimraf": "^2.6.2",
+    "superagent": "^7.0.2",
     "update-check": "^1.5.3",
     "urllib": "^2.29.1"
   },

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -175,7 +175,7 @@ async function img2Cos(article) {
   const urlList = await Promise.all(promiseList);
   urlList.forEach(function(url) {
     if (url) {
-      article.body = article.body.replace(url.originalUrl, `![image](${url.url})`);
+      article.body = article.body.replace(url.originalUrl, `![](${url.url})`);
       out.info(`replace ${url.yuqueRealImgUrl} to ${url.url}`);
     }
   });

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -136,6 +136,7 @@ async function img2Cos(article) {
   if (!article.body && !article.title) return article;
   // 1。从文章中获取语雀的图片URL列表
   const matchYuqueImgUrlList = article.body.match(imageUrlRegExp);
+  if (!matchYuqueImgUrlList) return article;
   const promiseList = matchYuqueImgUrlList.map(async matchYuqueImgUrl => {
     // 获取真正的图片url
     const yuqueImgUrl = getImgUrl(matchYuqueImgUrl);

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -85,15 +85,12 @@ async function hasObject(fileName) {
     out.error('请检查COS配置');
     process.exit(-1);
   }
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     cos.headObject({
       Bucket: bucket, // 存储桶名字（必须）
       Region: region, // 存储桶所在地域，必须字段
       Key: `${prefixKey}/${fileName}`, //  文件名  必须
     }, function(err, data) {
-      if (err) {
-        reject(err);
-      }
       if (data) {
         const url = `https://${bucket}.cos.${region}.myqcloud.com/${prefixKey}/${fileName}`;
         resolve(url);

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -28,19 +28,24 @@ const imageUrlRegExp = /!\[(.*?)]\((.*?)\)/mg;
  */
 async function img2Buffer(yuqueImgUrl) {
   return await new Promise(async function(resolve) {
-    await superagent
-      .get(yuqueImgUrl)
-      .buffer(true)
-      .parse(res => {
-        const buffer = [];
-        res.on('data', chunk => {
-          buffer.push(chunk);
+    try {
+      await superagent
+        .get(yuqueImgUrl)
+        .buffer(true)
+        .parse(res => {
+          const buffer = [];
+          res.on('data', chunk => {
+            buffer.push(chunk);
+          });
+          res.on('end', () => {
+            const data = Buffer.concat(buffer);
+            resolve(data);
+          });
         });
-        res.on('end', () => {
-          const data = Buffer.concat(buffer);
-          resolve(data);
-        });
-      });
+    } catch (e) {
+      out.warn(`invalid img: ${yuqueImgUrl}`);
+      resolve(null);
+    }
   });
 }
 
@@ -69,7 +74,6 @@ async function getFileName(imgBuffer, yuqueImgUrl) {
       const imgName = hash;
       const imgSuffix = yuqueImgUrl.substring(yuqueImgUrl.lastIndexOf('.'));
       const fileName = `${imgName}${imgSuffix}`;
-      // console.log('根据文件内容获取唯一文件名', fileName)
       resolve(fileName);
     });
   });
@@ -140,16 +144,20 @@ async function img2Cos(article) {
   const promiseList = matchYuqueImgUrlList.map(async matchYuqueImgUrl => {
     // 获取真正的图片url
     const yuqueImgUrl = getImgUrl(matchYuqueImgUrl);
-    // console.log('yuqueImgUrl', yuqueImgUrl)
     // 2。将图片转成buffer
     const imgBuffer = await img2Buffer(yuqueImgUrl);
+    if (!imgBuffer) {
+      return {
+        originalUrl: matchYuqueImgUrl,
+        yuqueRealImgUrl: yuqueImgUrl,
+        url: yuqueImgUrl,
+      };
+    }
     // 3。根据buffer文件生成唯一的hash文件名
     const fileName = await getFileName(imgBuffer, yuqueImgUrl);
-    // console.log('fileName', fileName)
     try {
       // 4。检查COS是否存在该文件
       let url = await hasObject(fileName);
-      // console.log('url', url)
       // 5。如果COS已经存在，直接替换；如果COS不存在，则先上传到COS，再将原本的语雀url进行替换
       if (!url) {
         url = await uploadImg(imgBuffer, fileName);

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -23,8 +23,9 @@ const imageUrlRegExp = /!\[(.*?)]\((.*?)\)/mg;
 
 /**
  * 将图片转成buffer
- * @param yuqueImgUrl
- * @return {Promise<Buffer>}
+ *
+ * @param {string} yuqueImgUrl 语雀图片url
+ * @return {Promise<Buffer>} 文件buffer
  */
 async function img2Buffer(yuqueImgUrl) {
   return await new Promise(async function(resolve) {
@@ -51,8 +52,9 @@ async function img2Buffer(yuqueImgUrl) {
 
 /**
  * 从markdown格式的url中获取url
- * @param markdownImgUrl
- * @return {string}
+ *
+ * @param {string} markdownImgUrl markdown语法图片
+ * @return {string} 图片url
  */
 function getImgUrl(markdownImgUrl) {
   const _temp = markdownImgUrl.replace(/\!\[(.*?)]\(/, '');
@@ -64,9 +66,10 @@ function getImgUrl(markdownImgUrl) {
 
 /**
  * 根据文件内容获取唯一文件名
- * @param imgBuffer
- * @param yuqueImgUrl
- * @return {Promise<string>}
+ *
+ * @param {Buffer} imgBuffer 文件buffer
+ * @param {string} yuqueImgUrl 语雀图片url
+ * @return {Promise<string>} 图片文件名称
  */
 async function getFileName(imgBuffer, yuqueImgUrl) {
   return new Promise(resolve => {
@@ -81,8 +84,9 @@ async function getFileName(imgBuffer, yuqueImgUrl) {
 
 /**
  * 检查COS是否已经存在图片，存在则返回url
- * @param fileName
- * @return {Promise<string>}
+ *
+ * @param {string} fileName 文件名
+ * @return {Promise<string>} 图片url
  */
 async function hasObject(fileName) {
   if (!bucket.length || !region.length) {
@@ -108,9 +112,10 @@ async function hasObject(fileName) {
 
 /**
  * 上传图片到COS
- * @param imgBuffer
- * @param fileName
- * @return {Promise<string>}
+ *
+ * @param {Buffer} imgBuffer 文件buffer
+ * @param {string} fileName 文件名
+ * @return {Promise<string>} 图床的图片url
  */
 async function uploadImg(imgBuffer, fileName) {
   return new Promise((resolve, reject) => {
@@ -132,9 +137,10 @@ async function uploadImg(imgBuffer, fileName) {
 }
 
 /**
- * 将aiticle中body中的语雀url进行替换
- * @param article
- * @return {*}
+ * 将article中body中的语雀url进行替换
+ *
+ * @param {*} article 文章
+ * @return {*} 文章
  */
 async function img2Cos(article) {
   if (!article.body && !article.title) return article;

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const COS = require('cos-nodejs-sdk-v5');
+const superagent = require('superagent');
+const getEtag = require('../lib/qetag');
+const config = require('../config');
+const out = require('../lib/out');
+
+const bucket = config.imgCdn.bucket;
+const region = config.imgCdn.region;
+const prefixKey = config.imgCdn.prefixKey;
+
+const secretId = process.env.SECRET_ID;
+const secretKey = process.env.SECRET_KEY;
+
+const cos = new COS({
+  SecretId: secretId, // 身份识别ID
+  SecretKey: secretKey, // 身份秘钥
+});
+
+// 获取语雀的图片链接的正则表达式
+const imageUrlRegExp = /!\[(.*?)]\((.*?)\)/mg;
+
+/**
+ * 将图片转成buffer
+ * @param yuqueImgUrl
+ * @return {Promise<Buffer>}
+ */
+async function img2Buffer(yuqueImgUrl) {
+  return await new Promise(async function(resolve) {
+    await superagent
+      .get(yuqueImgUrl)
+      .buffer(true)
+      .parse(res => {
+        const buffer = [];
+        res.on('data', chunk => {
+          buffer.push(chunk);
+        });
+        res.on('end', () => {
+          const data = Buffer.concat(buffer);
+          resolve(data);
+        });
+      });
+  });
+}
+
+/**
+ * 从markdown格式的url中获取url
+ * @param markdownImgUrl
+ * @return {string}
+ */
+function getImgUrl(markdownImgUrl) {
+  const _temp = markdownImgUrl.replace(/\!\[(.*?)]\(/, '');
+  const _temp_index = _temp.indexOf(')');
+  // 得到真正的语雀的url
+  return _temp.substring(0, _temp_index)
+    .split('#')[0];
+}
+
+/**
+ * 根据文件内容获取唯一文件名
+ * @param imgBuffer
+ * @param yuqueImgUrl
+ * @return {Promise<string>}
+ */
+async function getFileName(imgBuffer, yuqueImgUrl) {
+  return new Promise(resolve => {
+    getEtag(imgBuffer, hash => {
+      const imgName = hash;
+      const imgSuffix = yuqueImgUrl.substring(yuqueImgUrl.lastIndexOf('.'));
+      const fileName = `${imgName}${imgSuffix}`;
+      // console.log('根据文件内容获取唯一文件名', fileName)
+      resolve(fileName);
+    });
+  });
+}
+
+/**
+ * 检查COS是否已经存在图片，存在则返回url
+ * @param fileName
+ * @return {Promise<string>}
+ */
+async function hasObject(fileName) {
+  if (!bucket.length || !region.length) {
+    out.error('请检查COS配置');
+    process.exit(-1);
+  }
+  return new Promise((resolve, reject) => {
+    cos.headObject({
+      Bucket: bucket, // 存储桶名字（必须）
+      Region: region, // 存储桶所在地域，必须字段
+      Key: `${prefixKey}/${fileName}`, //  文件名  必须
+    }, function(err, data) {
+      if (err) {
+        reject(err);
+      }
+      if (data) {
+        const url = `https://${bucket}.cos.${region}.myqcloud.com/${prefixKey}/${fileName}`;
+        resolve(url);
+      } else {
+        resolve('');
+      }
+    });
+  });
+
+}
+
+/**
+ * 上传图片到COS
+ * @param imgBuffer
+ * @param fileName
+ * @return {Promise<string>}
+ */
+async function uploadImg(imgBuffer, fileName) {
+  return new Promise((resolve, reject) => {
+    cos.putObject({
+      Bucket: bucket, // 存储桶名字（必须）
+      Region: region, // 存储桶所在地域，必须字段
+      Key: `${prefixKey}/${fileName}`, //  文件名  必须
+      StorageClass: 'STANDARD', // 上传模式（标准模式）
+      Body: imgBuffer, // 上传文件对象
+    }, function(err, data) {
+      if (data) {
+        resolve(`https://${data.Location}`);
+      }
+      if (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+/**
+ * 将aiticle中body中的语雀url进行替换
+ * @param article
+ * @return {*}
+ */
+async function img2Cos(article) {
+  if (!article.body && !article.title) return article;
+  // 1。从文章中获取语雀的图片URL列表
+  const matchYuqueImgUrlList = article.body.match(imageUrlRegExp);
+  const promiseList = matchYuqueImgUrlList.map(async matchYuqueImgUrl => {
+    // 获取真正的图片url
+    const yuqueImgUrl = getImgUrl(matchYuqueImgUrl);
+    // console.log('yuqueImgUrl', yuqueImgUrl)
+    // 2。将图片转成buffer
+    const imgBuffer = await img2Buffer(yuqueImgUrl);
+    // 3。根据buffer文件生成唯一的hash文件名
+    const fileName = await getFileName(imgBuffer, yuqueImgUrl);
+    // console.log('fileName', fileName)
+    try {
+      // 4。检查COS是否存在该文件
+      let url = await hasObject(fileName);
+      // console.log('url', url)
+      // 5。如果COS已经存在，直接替换；如果COS不存在，则先上传到COS，再将原本的语雀url进行替换
+      if (!url) {
+        url = await uploadImg(imgBuffer, fileName);
+      }
+      return {
+        originalUrl: matchYuqueImgUrl,
+        yuqueRealImgUrl: yuqueImgUrl,
+        url,
+      };
+    } catch (e) {
+      out.error('访问COS出错，请检查配置');
+      process.exit(-1);
+    }
+  });
+  const urlList = await Promise.all(promiseList);
+  urlList.forEach(function(url) {
+    if (url) {
+      article.body = article.body.replace(url.originalUrl, `![image](${url.url})`);
+      out.info(`replace ${url.yuqueRealImgUrl} to ${url.url}`);
+    }
+  });
+  return article;
+}
+
+module.exports = img2Cos;
+

--- a/util/img2cdn.js
+++ b/util/img2cdn.js
@@ -143,7 +143,6 @@ async function uploadImg(imgBuffer, fileName) {
  * @return {*} 文章
  */
 async function img2Cos(article) {
-  if (!article.body && !article.title) return article;
   // 1。从文章中获取语雀的图片URL列表
   const matchYuqueImgUrlList = article.body.match(imageUrlRegExp);
   if (!matchYuqueImgUrlList) return article;


### PR DESCRIPTION
博主您好，基于语雀的url防盗链的问题，我这边改造了一下适配器，可以实现语雀URL上传到腾讯云的COS中并替换原链接。
如果您觉得不妥或者可以作为试验，可以考虑合入试验分支。

### 配置 腾讯云对象存储TOKEN(可选)
语雀的url存在防盗链的问题，直接部署可能导致图片无法加载。
如果需要语雀URL上传到腾讯云的COS中并替换原链接，就需要配置上传密钥。

访问[API密钥管理](https://console.cloud.tencent.com/cam/capi) 获取密钥，然后传入密钥到yuque-hexo
- 在设置YUQUE_TOKEN的基础上配置SECRET_ID和SECRET_KEY
- 命令执行时传入环境变量
  - mac / linux: `YUQUE_TOKEN=xxx SECRET_ID=xxx SECRET_KEY=xxx yuque-hexo sync`
  - windows: `set YUQUE_TOKEN=xxx SECRET_ID=xxx SECRET_KEY=xxx && yuque-hexo sync`

imgCdn 语雀图片转COS（对象存储）配置说明

注意：开启后会将匹配到的所有的图片都上传到COS

| 参数名        | 含义                                 | 默认值               |
| ------------- | ------------------------------------ | -------------------- |
| enabled       | 是否开启                           | false |
| bucket        | 腾讯COS的bucket名称                     | -          |
| region        | 腾讯COS的region(地域名称)               |  -                     |
| prefixKey     | 文件前缀                                | -                |
> prefixKey 说明
> 
> 如果需要将图片上传到COS的根目录，那么prefixKey不用配置。
> 
> 如果想上传到指定目录blog/image下，则需要配置prefixKey为"prefixKey": "blog/image"。
>
> 目录名前后都不需要加斜杠

为什么选择腾讯COS作为图床：腾讯的COS费用相对便宜，对于博客来说是非常划算且方便的。
当然，如果想用其他图床，可以参考源码中实现方式，自行修改配置。